### PR TITLE
feat: reject promises with error object

### DIFF
--- a/src/services/sigep/buscaCEP.ts
+++ b/src/services/sigep/buscaCEP.ts
@@ -7,8 +7,7 @@ export default async function buscaCEP(cep: string): Promise<ICep> {
   return new Promise((resolve, reject: any) => {
     client.consultaCEP({ cep }, (error: IError, result: { return: ICep }) => {
       if (error) {
-        const _error = error.root.Envelope.Body.Fault.faultstring;
-        reject(_error) ? error.root : error;
+        reject(error);
       } else {
         resolve(result.return);
       }

--- a/src/services/sigep/buscaCliente.ts
+++ b/src/services/sigep/buscaCliente.ts
@@ -9,8 +9,7 @@ export default async function buscaCliente(userData: IUser): Promise<ICliente> {
       userData,
       (error: IError, result: { return: ICliente }) => {
         if (error) {
-          const _error = error.root.Envelope.Body.Fault.faultstring;
-          reject(_error) ? error.root : error;
+          reject(error);
         } else {
           resolve(result.return);
         }

--- a/src/services/sigep/buscaStatusCartaoPostagem.ts
+++ b/src/services/sigep/buscaStatusCartaoPostagem.ts
@@ -11,8 +11,7 @@ export default async function buscaStatusCartaoPostagem(
       requestData,
       (error: IError, result: { return: string }) => {
         if (error) {
-          const _error = error.root.Envelope.Body.Fault.faultstring;
-          reject(_error) ? error.root : error;
+          reject(error);
         } else {
           resolve(result.return);
         }

--- a/src/services/sigep/fechaPlpVariosServicos.ts
+++ b/src/services/sigep/fechaPlpVariosServicos.ts
@@ -18,8 +18,7 @@ export default async function fechaPlpVariosServicos(
       { xml: JS2XML, ...requestData },
       (error: IError, result: { return: string }) => {
         if (error) {
-          const _error = error.root.Envelope.Body.Fault.faultstring;
-          reject(_error) ? error.root : error;
+          reject(error);
         } else {
           resolve(result.return);
         }

--- a/src/services/sigep/solicitaEtiquetas.ts
+++ b/src/services/sigep/solicitaEtiquetas.ts
@@ -11,8 +11,7 @@ export default async function solicitaEtiquetas(
       requestData,
       (error: IError, result: { return: string }) => {
         if (error) {
-          const _error = error.root.Envelope.Body.Fault.faultstring;
-          reject(_error) ? error.root : error;
+          reject(error);
         } else {
           const response = result.return.split(',');
           resolve(response);

--- a/src/services/sigep/solicitaXmlPlp.ts
+++ b/src/services/sigep/solicitaXmlPlp.ts
@@ -10,7 +10,7 @@ export default async function solicitaXmlPlp(
     client.solicitaXmlPlp(requestData, (error: IError, result: any) => {
       if (error) {
         const _error = error.root.Envelope.Body.Fault.faultstring;
-        reject(_error) ? error.root : error;
+        reject(error);
       } else {
         resolve(result.return);
       }

--- a/src/services/sigep/solicitaXmlPlp.ts
+++ b/src/services/sigep/solicitaXmlPlp.ts
@@ -9,7 +9,6 @@ export default async function solicitaXmlPlp(
   return new Promise((resolve, reject: any) => {
     client.solicitaXmlPlp(requestData, (error: IError, result: any) => {
       if (error) {
-        const _error = error.root.Envelope.Body.Fault.faultstring;
         reject(error);
       } else {
         resolve(result.return);

--- a/src/services/sigep/verificaDisponibilidadeServico.ts
+++ b/src/services/sigep/verificaDisponibilidadeServico.ts
@@ -11,8 +11,7 @@ export default async function verificaDisponibilidadeServico(
       requestData,
       (error: IError, result: any) => {
         if (error) {
-          const _error = error.root.Envelope.Body.Fault.faultstring;
-          reject(_error) ? error.root : error;
+          reject(error);
         } else {
           resolve(result.return);
         }


### PR DESCRIPTION
Pode ser uma breaking change em alguns casos, ao invés de rejeitar as `promises` com a descrição do erro, agora é rejeitado com todo o objeto. O objetivo é facilitar aos desenvolvedores realizar uma depuração mais rápida.