### PR TITLE
fix: etiquetas range starting with zero

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -41,11 +41,11 @@ const etiquetasRange = (etiquetas: Array<string>, isDigit: boolean) => {
   const etiquetasList = [];
   if (isDigit) {
     for (let etiqueta = inicio; etiqueta <= fim; etiqueta++) {
-      etiquetasList.push(digitoVerificador(`${prefix}${etiqueta} ${sufix}`));
+      etiquetasList.push(digitoVerificador(`${prefix}${etiqueta.toString().padStart(8, '0')} ${sufix}`));
     }
   } else {
     for (let etiqueta = inicio; etiqueta <= fim; etiqueta++) {
-      etiquetasList.push(`${prefix}${etiqueta}${sufix}`);
+      etiquetasList.push(`${prefix}${etiqueta.toString().padStart(8, '0')}${sufix}`);
     }
   }
   return etiquetasList;


### PR DESCRIPTION
Detectei que ao utilizar a função `etiquetasRangeComDigito` com intervalo de etiquetas que começam com o dígito `0` não é gerado o dígito verificador com sucesso.

Exemplo:

O seguinte intervalo de etiquetas retornam etiquetas com erro

```jsx
etiquetasRangeComDigito(['QG02210231 BR', 'QG02210233 BR']) // [ 'QG2210231 NaNBR','QG2210232 NaNBR','QG2210233 NaNBR' ]
```

As alterações corrigem esta função para este caso de etiquetas que começam com `0`.